### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ Made by [![Appus Studio](https://github.com/appus-studio/Appus-Splash/blob/maste
 * [Info](#info)
 
 # Demo
-##Example animating
+## Example animating
 ![](https://raw.githubusercontent.com/alexey-kubas-appus/CircleTimer/master/Resources/demo.gif)
-##Example configuring
+## Example configuring
 ![](https://raw.githubusercontent.com/alexey-kubas-appus/CircleTimer/master/Resources/using_ib_inspectable.gif)
 
 ```Ruby
 pod 'CircleCounter'
 ```
 
-##Usage example:
+## Usage example:
 
 self.timeCircle.totalTime = 5;
 self.timeCircle.elapsedTime = 0;


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
